### PR TITLE
ADD: Add a template with the name initial-deployment.yaml to trigger create-image.yml github actions

### DIFF
--- a/Docker-files/flask/.dockerignore
+++ b/Docker-files/flask/.dockerignore
@@ -1,0 +1,12 @@
+.idea/
+.vscode/
+
+*venv/
+__pycache__/
+
+Dockerfile
+
+.gitignore
+README.md
+.git/
+.github

--- a/Docker-files/flask/Dockerfile
+++ b/Docker-files/flask/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.12.3-slim AS base
+# ------------------------ Initial image build ---------------------------
+FROM base AS build
+
+WORKDIR /usr/app
+
+RUN python -m venv /usr/app/venv
+ENV PATH="/usr/app/venv/bin:$PATH"
+
+COPY requirements.txt .
+RUN echo "gunicorn==20.0.4" >> requirements.txt
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	      build-essential gcc && pip install -r requirements.txt
+
+# ------------------------ Production Build -------------------------------
+FROM base
+
+RUN groupadd -g 999 python && \
+    useradd -r -u 999 -g python python
+
+RUN mkdir /usr/app && chown python:python /usr/app
+
+WORKDIR /usr/app
+
+COPY --chown=python:python --from=build /usr/app/venv ./venv
+COPY --chown=python:python . .
+
+USER 999
+
+ENV PATH="/usr/app/venv/bin:$PATH"
+CMD [ "gunicorn", "--bind", "0.0.0.0:3000", "manage:app" ]

--- a/Docker-files/node-js/.dockerignore
+++ b/Docker-files/node-js/.dockerignore
@@ -1,0 +1,13 @@
+dist-types
+node_modules
+
+packages/*/dist
+packages/*/node_modules
+plugins/*/dist
+plugins/*/node_modules
+
+Dockerfile
+.dockerignore
+
+.git
+.gitignore

--- a/Docker-files/node-js/.dockerignore
+++ b/Docker-files/node-js/.dockerignore
@@ -1,5 +1,8 @@
 dist-types
 node_modules
+dist
+build
+
 
 packages/*/dist
 packages/*/node_modules
@@ -10,4 +13,5 @@ Dockerfile
 .dockerignore
 
 .git
+.github
 .gitignore

--- a/Docker-files/node-js/Dockerfile
+++ b/Docker-files/node-js/Dockerfile
@@ -1,0 +1,27 @@
+
+# ---------------------- Initial image build ---------------------
+FROM node:20.12.2-bullseye-slim AS build
+
+WORKDIR /usr/src/app
+
+COPY package*.json /usr/src/app/
+
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends dumb-init \ 
+&& npm ci --only=production
+
+# ------------------------ Production Image ---------------------
+FROM node:20.12.2-bullseye-slim
+
+ENV NODE_ENV production
+
+COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init
+
+USER node
+
+WORKDIR /usr/src/app
+
+COPY --chown=node:node --from=build /usr/src/app/node_modules /usr/src/app/node_modules
+COPY --chown=node:node . /usr/src/app
+
+CMD ["dumb-init", "node", "server.js"]

--- a/Docker-files/node-js/Dockerfile
+++ b/Docker-files/node-js/Dockerfile
@@ -1,6 +1,6 @@
-
+FROM node:20.12.2-bullseye-slim AS base
 # ---------------------- Initial image build ---------------------
-FROM node:20.12.2-bullseye-slim AS build
+FROM base AS build
 
 WORKDIR /usr/src/app
 
@@ -11,15 +11,15 @@ RUN apt-get update \
 && npm ci --only=production
 
 # ------------------------ Production Image ---------------------
-FROM node:20.12.2-bullseye-slim
+FROM base
+
+WORKDIR /usr/src/app
 
 ENV NODE_ENV production
 
 COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init
 
 USER node
-
-WORKDIR /usr/src/app
 
 COPY --chown=node:node --from=build /usr/src/app/node_modules /usr/src/app/node_modules
 COPY --chown=node:node . /usr/src/app

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -19,8 +19,8 @@ backend:
     client: pg
     connection:
       host: ${POSTGRES_HOST}
-      port: ${POSTGRES_PORT} 
-      user: ${POSTGRES_USER} 
+      port: ${POSTGRES_PORT}
+      user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
 
 integrations:
@@ -34,7 +34,6 @@ techdocs:
     runIn: 'docker' # Alternatives - 'local'
   publisher:
     type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
-
 
 catalog:
   import:
@@ -64,13 +63,18 @@ catalog:
       rules:
         - allow: [Template]
 
+    - type: file
+      target: ../../packages/backend/src/templates/initial-deployment/initial-deployment.yaml
+      rules:
+        - allow: [Template]
+
 auth:
   # see https://backstage.io/docs/auth/ to learn about auth providers
   environment: development
-  providers: 
+  providers:
     github:
       development:
-        clientId:  ${GITHUB_CLIENT_ID} 
+        clientId: ${GITHUB_CLIENT_ID}
         clientSecret: ${GITHUB_CLIENT_SECRET}
 
 kubernetes:
@@ -80,7 +84,7 @@ kubernetes:
     - type: config
       clusters:
         - url: ${K8S_URL}
-          name: "k8s"
+          name: 'k8s'
           authProvider: serviceAccount
           skipTLSVerify: false
           skipMetricsLookup: true

--- a/packages/backend/src/templates/initial-deployment/initial-deployment.yaml
+++ b/packages/backend/src/templates/initial-deployment/initial-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-template
+kind: Template
+metadata:
+  name: GKE-cluster
+  title: Initial Deployment.
+  description: Deploy application to google cloud.
+spec:
+  owner: user:guest
+  type: service
+
+  # These parameters are used to generate the input form in the frontend, and are
+  # used to gather input data for the execution of the template.
+  parameters:
+    - title: Public github repo link to deploy
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Public github Repo to deploy
+          description: Provide the github repository link in the following format <https://github.com/your_user_name/your_repository_name>
+          pattern: ^https:\/\/github\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]
+          type: string
+          ui:options:
+            allowedHosts:
+              - github.com
+
+  # These steps are executed in the scaffolder backend, using data that we gathered
+  # via the parameters above.
+  steps:
+    # Start a github Action to build a GKE cluster with Terraform
+    - id: github-action
+      name: Trigger Github Action
+      action: github:actions:dispatch
+      input:
+        workflowId: initial-deployment-workflow.yml
+        repoUrl: 'https://github.com/codeuniversity/code-idp?repo=code-idp&owner=codeuniversity'
+        branchOrTagName: 'main'
+        workflowInputs:
+          githubRepo: ${{ parameters.repoUrl }}


### PR DESCRIPTION
This pull request contains the template responsible for triggering the github actions create-image.yml in the [idp-hosted-projects](https://github.com/codeuniversity/idp-hosted-projects) to do the following:
- Create a submodule based on the student's repository. 
- Build a docker image based on the repository's dependencies. 
- Push it to the Google Cloud artifact registry. 
- Trigger the deployment process for that registry. 

Please note that to run this template locally, you need to follow this tutorial: [Grant SAML access](https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on)