### PR TITLE
Run GitHub Actions to Run Only on Pull Requests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,11 +1,11 @@
-name: Test and E2E tests
-run-name: Run tests and E2E tests
+name: Test and E2E tests on PR
+run-name: Run tests and E2E tests on PR
 
 on:  
-  push:
   pull_request:
     branches:
       - main
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -21,18 +21,13 @@ jobs:
   run-e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 #chekcout te repository
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3 #setup node version 20
+        uses: actions/setup-node@v3
         with:
           node-version: '20'
-
-      - name: Install dependencies #install dependencies
-        run: yarn install
-
+      - run: yarn install
       - name: Run E2E tests
         env:
-          PLAYWRIGHT_URL: http://localhost:3000 # set the URL of the app to test with playwright
-          CI: # unset CI because it is set by default in Github actions
-        run: |
-          yarn test:e2e
+          PLAYWRIGHT_URL: http://localhost:3000
+        run: yarn test:e2e


### PR DESCRIPTION
I updated the GitHub Actions workflow to trigger only on PRs now targeting the main branch primarily to:
- minimise use of our CI/CD resources
- speed up development

**NOTE:** This change requires that all team members make sure that their code compiles and passes all of the tests locally before creating a PR. You can do this with the `pre-hook` found in our [Wiki](https://github.com/codeuniversity/code-idp/wiki/Commiting-to-Git#git-hooks).